### PR TITLE
👍 apiの矛先を変更

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,7 @@ preview_urls = false
 
 [vars]
 APP_URL = "https://local.kotohiro.com:3000"
-API_URL = "https://api-dev.kotohiro.com"
+API_URL = "https://api.dev.kotohiro.com"
 
 # 開発環境の設定
 [env.develop]
@@ -19,7 +19,7 @@ routes = [
 
 [env.develop.vars]
 APP_URL = "https://develop.kotohiro.com"
-API_URL = "https://api-dev.kotohiro.com"
+API_URL = "https://api.dev.kotohiro.com"
 
 # ステージング環境の設定
 [env.staging]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - 開発環境のAPIエンドポイントを正しいドメインに更新（api-dev → api.dev）。接続の安定性と設定の一貫性が向上します。
  - 設定変更のみであり、機能追加やUIの変更はありません。
  - 開発・検証時の通信失敗やCORS不整合の発生リスクを低減します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->