### PR TITLE
環境指定をCLOUDFLARE_ENVに統一

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run typecheck
         env:
-          CF_ENV: develop
+          CLOUDFLARE_ENV: develop
         run: pnpm typecheck
 
       - name: Run Lint

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,9 +6,8 @@ import { defineConfig } from "vite";
 import { getPlatformProxy } from "wrangler";
 
 export default defineConfig(async () => {
-  // @cloudflare/vite-plugin が参照する CLOUDFLARE_ENV に統一する。
-  // CF_ENV は旧来の指定方法との互換のためのフォールバック
-  const cloudflareEnv = process.env.CLOUDFLARE_ENV || process.env.CF_ENV;
+  // 環境指定は @cloudflare/vite-plugin が参照する CLOUDFLARE_ENV に統一
+  const cloudflareEnv = process.env.CLOUDFLARE_ENV;
   const proxy = await getPlatformProxy({
     environment: cloudflareEnv || "develop",
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,11 @@ import { defineConfig } from "vite";
 import { getPlatformProxy } from "wrangler";
 
 export default defineConfig(async () => {
+  // @cloudflare/vite-plugin が参照する CLOUDFLARE_ENV に統一する。
+  // CF_ENV は旧来の指定方法との互換のためのフォールバック
+  const cloudflareEnv = process.env.CLOUDFLARE_ENV || process.env.CF_ENV;
   const proxy = await getPlatformProxy({
-    environment: process.env.CF_ENV || "develop",
+    environment: cloudflareEnv || "develop",
   });
   const { APP_URL, API_URL } = proxy.env;
 
@@ -27,7 +30,7 @@ export default defineConfig(async () => {
   };
 
   return {
-    server: process.env.CF_ENV ? undefined : server,
+    server: cloudflareEnv ? undefined : server,
     define: {
       APP_URL: `${JSON.stringify(APP_URL)}`,
       API_URL: `${JSON.stringify(API_URL)}`,


### PR DESCRIPTION
## 概要

環境の指定が2系統に分かれていたのを `CLOUDFLARE_ENV` に統一します。

- `CLOUDFLARE_ENV` … `@cloudflare/vite-plugin` が読む(ワーカーの name / vars / ルートの生成元)
- `CF_ENV` … `vite.config.ts` の `getPlatformProxy` が読む(バンドルに焼き込まれる `APP_URL` / `API_URL` 定数の取得元)

このままだと Cloudflare Workers Builds で環境ごとに2つの変数を設定する必要があり、片方を忘れると「ワーカー設定は本番なのに焼き込みURLは develop」といった不整合が起きます。

## 変更内容

- `vite.config.ts`: `CF_ENV` を廃止し、`CLOUDFLARE_ENV` のみを参照する(dev サーバー設定の切り替えも同じ値を使用)
- `.github/workflows/test.yml`: typecheck の環境指定を `CLOUDFLARE_ENV: develop` に変更

## 動作確認

- `CLOUDFLARE_ENV=staging pnpm run build` で、生成された `build/server/wrangler.json` が `name: kotohiro-staging` + staging の vars になり、サーバーバンドルに `staging.kotohiro.com` が焼き込まれることを確認
- `pnpm lint` / `CLOUDFLARE_ENV=develop pnpm typecheck` 通過

## マージ後の運用

- Workers Builds の各プロジェクトは、ビルドコマンドの `CLOUDFLARE_ENV=<env>` だけで完結します(ダッシュボードの `CF_ENV` 変数は不要になるため削除してください)
- ローカルで環境を指定する場合も `CF_ENV=xxx` ではなく `CLOUDFLARE_ENV=xxx` を使ってください(`CF_ENV` はもう読まれません)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbCNKjDTCLndVGkE4qYENu