### PR TITLE
🎨 Header: ログインボタンの色を #007AFF に変更し文言を「ログインする」に修正

### DIFF
--- a/app/routes/_pages/components/Header/index.tsx
+++ b/app/routes/_pages/components/Header/index.tsx
@@ -89,10 +89,10 @@ export const Header = ({ $user }: Props) => {
                         to={"/"}
                         className={button({
                           className:
-                            "flex h-8 items-center rounded-md bg-[#32ADE6] p-2 text-xs",
+                            "flex h-8 items-center rounded-md bg-[#007AFF] p-2 text-xs",
                         })}
                       >
-                        ログイン
+                        ログインする
                       </Link>
                     );
                   }


### PR DESCRIPTION
## 概要

### ログインボタンのUI変更
- **背景・目的**: ヘッダーのログインボタンの視認性を改善する
- **変更内容**: ボタン色を #32ADE6 → #007AFF に変更、文言を「ログイン」→「ログインする」に変更
- **該当コミット**: 008739a 🎨 Header: ログインボタンの色を #007AFF に変更し文言を「ログインする」に修正

## テスト
- [ ] ヘッダーのログインボタンの色が #007AFF であることを確認
- [ ] ボタンの文言が「ログインする」になっていることを確認