### PR TITLE
🎨 Header: 高さを80pxに変更しロゴサイズも調整

### DIFF
--- a/app/routes/_pages/components/Header/index.tsx
+++ b/app/routes/_pages/components/Header/index.tsx
@@ -56,14 +56,14 @@ export const Header = ({ $user }: Props) => {
           isDialogOpen: isMenuDialogOpen || isSearchDialogOpen,
         })}
       >
-        <span className="relative flex h-12 w-full items-center bg-white px-4">
+        <span className="relative flex h-20 w-full items-center bg-white px-4">
           <Suspense
-            fallback={<img src={LogoIcon} alt="" className="h-8 w-[109px]" />}
+            fallback={<img src={LogoIcon} alt="" className="h-14 w-[191px]" />}
           >
             <Await resolve={$user}>
               {(user) => (
                 <a href={user ? "/home" : "/"} className="mr-auto">
-                  <img src={LogoIcon} alt="" className="h-8 w-[109px]" />
+                  <img src={LogoIcon} alt="" className="h-14 w-[191px]" />
                 </a>
               )}
             </Await>
@@ -132,7 +132,7 @@ export const Header = ({ $user }: Props) => {
       </header>
 
       {/* スペーサー */}
-      <div className="h-12 w-full" />
+      <div className="h-20 w-full" />
 
       {/* 各種ダイアログ */}
       <SearchModal

--- a/app/routes/_pages/route.tsx
+++ b/app/routes/_pages/route.tsx
@@ -38,7 +38,7 @@ export default function Layout({
         className={
           isTopPage
             ? "flex min-h-screen flex-col"
-            : "flex min-h-[calc(100vh-48px)] flex-col"
+            : "flex min-h-[calc(100vh-80px)] flex-col"
         }
       >
         <Outlet context={{ $user } satisfies RouteContext} />


### PR DESCRIPTION
## 概要

### Headerの高さ・ロゴサイズ調整
- **背景・目的**: Headerの視認性向上のため高さを拡大
- **変更内容**:
  - ヘッダー高さ: 48px → 80px (h-20)
  - ロゴサイズ: 32px → 56px (h-14, width 比例で191px)
  - メイン領域の min-height calc 値を 80px に合わせて更新
- **該当コミット**: 6ffd8a2 🎨 Header: 高さを80pxに変更しロゴサイズも調整

## テスト

- [ ] Headerが80pxの高さで表示されること
- [ ] ロゴが適切なサイズで表示されること
- [ ] メイン領域がHeaderの高さ分ずれて正しく表示されること
- [ ] モバイル表示でも崩れていないこと

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| app/routes/_pages/components/Header/index.tsx | h-12→h-20, h-8→h-14, w-[109px]→w-[191px] |
| app/routes/_pages/route.tsx | calc(100vh-48px)→calc(100vh-80px) |