### PR TITLE
✨ Flagship によるアンケート機能のフィーチャーフラグ制御を追加

### DIFF
--- a/app/routes/_pages.$session_id/modules/loader.ts
+++ b/app/routes/_pages.$session_id/modules/loader.ts
@@ -1,8 +1,8 @@
 import type { LoaderFunctionArgs } from "react-router";
+import { cloudflareContext } from "~/../workers/app";
 import { SURVEY_RESTRICTION_KEY } from "~/hooks/useVote";
 import { api } from "~/libs/openapi-fetch";
 import { notfound } from "~/utils/response";
-import { cloudflareContext } from "~/../workers/app";
 
 export const loader = async ({
   request,

--- a/app/routes/_pages.$session_id/modules/loader.ts
+++ b/app/routes/_pages.$session_id/modules/loader.ts
@@ -2,8 +2,15 @@ import type { LoaderFunctionArgs } from "react-router";
 import { SURVEY_RESTRICTION_KEY } from "~/hooks/useVote";
 import { api } from "~/libs/openapi-fetch";
 import { notfound } from "~/utils/response";
+import { cloudflareContext } from "~/../workers/app";
 
-export const loader = async ({ request, params }: LoaderFunctionArgs) => {
+export const loader = async ({
+  request,
+  params,
+  context,
+}: LoaderFunctionArgs) => {
+  const { env } = context.get(cloudflareContext);
+  const enableSurvey = await env.FLAGS.getBooleanValue("questionnaire", false);
   if (!params.session_id) {
     throw notfound();
   }
@@ -61,17 +68,19 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   /**
    * 入室前アンケート（未設定なら404でnull）
    */
-  const $survey = api
-    .GET("/talksessions/{talkSessionID}/survey", {
-      headers: request.headers,
-      params: {
-        path: {
-          talkSessionID: params.session_id,
-        },
-      },
-    })
-    .then(({ data }) => data || null)
-    .catch(() => null);
+  const $survey = enableSurvey
+    ? api
+        .GET("/talksessions/{talkSessionID}/survey", {
+          headers: request.headers,
+          params: {
+            path: {
+              talkSessionID: params.session_id,
+            },
+          },
+        })
+        .then(({ data }) => data || null)
+        .catch(() => null)
+    : Promise.resolve(null);
 
   /**
    * 制限項目リストの配列の中に足りていないフラグを仕込む処理
@@ -104,5 +113,6 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     $restrictions,
     $positions,
     $survey,
+    enableSurvey,
   };
 };

--- a/app/routes/_pages.$session_id/route.tsx
+++ b/app/routes/_pages.$session_id/route.tsx
@@ -40,7 +40,7 @@ type Tab = {
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
 
 export default function Layout({
-  loaderData: { $session, ...props },
+  loaderData: { $session, enableSurvey, ...props },
 }: Route.ComponentProps) {
   const { $user } = useOutletContext<RouteContext>();
 
@@ -51,7 +51,14 @@ export default function Layout({
           if (!session) {
             throw notfound();
           }
-          return <Contents session={session} $user={$user} {...props} />;
+          return (
+            <Contents
+              session={session}
+              $user={$user}
+              enableSurvey={enableSurvey}
+              {...props}
+            />
+          );
         }}
       </Await>
     </Suspense>
@@ -73,6 +80,7 @@ const Contents = ({
   $remainingCount,
   $positions,
   $survey,
+  enableSurvey,
 }: Props) => {
   const tabs = [
     { label: "内容", href: `/${session.id}` },
@@ -125,6 +133,9 @@ const Contents = ({
    * 未回答（未答フラグなし）ならアンケートダイアログを開く
    */
   useEffect(() => {
+    if (!enableSurvey) {
+      return;
+    }
     Promise.all([$user, $survey]).then(([user, surveyData]) => {
       if (!surveyData || surveyData.questions.length === 0) {
         return;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,8 +10,9 @@ export default defineConfig(async () => {
   const cloudflareEnv = process.env.CLOUDFLARE_ENV;
   const proxy = await getPlatformProxy({
     environment: cloudflareEnv || "develop",
-  });
-  const { APP_URL, API_URL } = proxy.env;
+  }).catch(() => null);
+  const APP_URL = proxy?.env?.APP_URL ?? "https://local.kotohiro.com:3000";
+  const API_URL = proxy?.env?.API_URL ?? "https://api.dev.kotohiro.com";
 
   if (typeof APP_URL !== "string" || typeof API_URL !== "string") {
     throw new Error("APP_URL or API_URL must be defined");

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -12982,6 +12982,7 @@ declare namespace Cloudflare {
     //
     // You can use `wrangler types` to generate the `Env` type automatically.
     interface Env {
+        FLAGS: Flagship;
     }
     // Project-specific parameters used to inform types.
     //

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,11 @@ compatibility_date = "2024-10-18"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 
+[[flagship]]
+binding = "FLAGS"
+project = "kotohiro"
+appId = "147cbe10-d9e4-448b-a419-fa5832509a8b"
+
 [vars]
 APP_URL = "https://local.kotohiro.com:3000"
 API_URL = "https://api.dev.kotohiro.com"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,8 +7,7 @@ workers_dev = false
 
 [[flagship]]
 binding = "FLAGS"
-project = "kotohiro"
-appId = "147cbe10-d9e4-448b-a419-fa5832509a8b"
+app_id = "147cbe10-d9e4-448b-a419-fa5832509a8b"
 
 [vars]
 APP_URL = "https://local.kotohiro.com:3000"
@@ -22,6 +21,10 @@ routes = [
   { pattern = "develop.kotohiro.com", custom_domain = true }
 ]
 
+[[env.develop.flagship]]
+binding = "FLAGS"
+app_id = "147cbe10-d9e4-448b-a419-fa5832509a8b"
+
 [env.develop.vars]
 APP_URL = "https://develop.kotohiro.com"
 API_URL = "https://api.dev.kotohiro.com"
@@ -33,6 +36,10 @@ preview_urls = false
 routes = [
   { pattern = "staging.kotohiro.com", custom_domain = true }
 ]
+
+[[env.staging.flagship]]
+binding = "FLAGS"
+app_id = "147cbe10-d9e4-448b-a419-fa5832509a8b"
 
 [env.staging.vars]
 APP_URL = "https://staging.kotohiro.com"
@@ -46,6 +53,10 @@ routes = [
   { pattern = "kotohiro.com", custom_domain = true },
   { pattern = "www.kotohiro.com", custom_domain = true }
 ]
+
+[[env.production.flagship]]
+binding = "FLAGS"
+app_id = "147cbe10-d9e4-448b-a419-fa5832509a8b"
 
 [env.production.vars]
 APP_URL = "https://www.kotohiro.com"


### PR DESCRIPTION
## 概要

### Flagship フィーチャーフラグによるアンケート機能の制御
- **背景・目的**: アンケート機能を Cloudflare Flagship 経由で動的に有効/無効化できるようにする
- **変更内容**:
  - `wrangler.toml`: Flagship バインディングを追加（project: kotohiro, appId: 147cbe10...）
  - `worker-configuration.d.ts`: Env に `FLAGS: Flagship` を追加
  - `app/routes/_pages.$session_id/modules/loader.ts`: cloudflareContext 経由でフラグ判定し、`enableSurvey = false` 時はアンケート API 呼び出しをスキップ
  - `app/routes/_pages.$session_id/route.tsx`: `enableSurvey` が false ならアンケート表示ロジックを実行しない
- **該当コミット**: 18d91c7 ✨ Flagship によるアンケート機能のフィーチャーフラグ制御を追加

## テスト
- [ ] Flagship バインディングが wrangler.toml に正しく設定されていること
- [ ] フラグ有効時: アンケートが設定されたセッションで入室前アンケートが表示されること
- [ ] フラグ無効時: アンケートが設定されていても表示されず、API 呼び出しも行われないこと
- [ ] `wrangler deploy` 後に Flagship ダッシュボードで `questionnaire` フラグが表示されること