### PR TITLE
✨ アンケートの質問設定をAPI仕様に追従させる

### DIFF
--- a/app/routes/_pages.$session_id/components/RequestsModal/components/SurveyModalContent/index.tsx
+++ b/app/routes/_pages.$session_id/components/RequestsModal/components/SurveyModalContent/index.tsx
@@ -337,32 +337,38 @@ export const SurveyModalContent = ({
         }),
     };
 
-    const { error, response } = await api.POST(
-      "/talksessions/{talkSessionID}/survey/submissions",
-      {
-        credentials: "include",
-        params: { path: { talkSessionID: sessionID } },
-        body,
-        // アンケートAPIはJSONを受け取るため、FormData変換を上書きする
-        bodySerializer: (b) => JSON.stringify(b),
-      },
-    );
-    setIsSubmitting(false);
+    try {
+      const { error, response } = await api.POST(
+        "/talksessions/{talkSessionID}/survey/submissions",
+        {
+          credentials: "include",
+          params: { path: { talkSessionID: sessionID } },
+          body,
+          // アンケートAPIはJSONを受け取るため、FormData変換を上書きする
+          bodySerializer: (b) => JSON.stringify(b),
+        },
+      );
 
-    // 1ユーザー1送信のため、回答済みなら409が返る
-    if (response.status === 409) {
-      toast.info("すでに回答済みです");
+      // 1ユーザー1送信のため、回答済みなら409が返る
+      if (response.status === 409) {
+        toast.info("すでに回答済みです");
+        onAnswered();
+        return;
+      }
+
+      if (error) {
+        toast.error(error.message || "回答の送信に失敗しました");
+        return;
+      }
+
+      toast.success("アンケートに回答しました");
       onAnswered();
-      return;
+    } catch {
+      // 通信自体が失敗した場合。握りつぶすと押しっぱなしで固まる
+      toast.error("回答の送信に失敗しました。通信環境をご確認ください");
+    } finally {
+      setIsSubmitting(false);
     }
-
-    if (error) {
-      toast.error(error.message || "回答の送信に失敗しました");
-      return;
-    }
-
-    toast.success("アンケートに回答しました");
-    onAnswered();
   };
 
   return (

--- a/app/routes/_pages.$session_id/components/RequestsModal/components/SurveyModalContent/index.tsx
+++ b/app/routes/_pages.$session_id/components/RequestsModal/components/SurveyModalContent/index.tsx
@@ -18,24 +18,249 @@ type Question = components["schemas"]["TalkSessionSurveyQuestion"];
  * - free_text: text
  * - rating: text（数値文字列）
  * - date: text（YYYY-MM-DD）
+ *
+ * allowOther=trueの選択肢系では、選択肢の代わり（single/dropdown）または
+ * 選択肢に加えて（multi）「その他」を選べる。otherSelected + other を使う
  */
 type AnswerDraft = {
   choiceIDs: string[];
   text: string;
+  otherSelected: boolean;
+  other: string;
 };
 
-const emptyAnswer: AnswerDraft = { choiceIDs: [], text: "" };
+const emptyAnswer: AnswerDraft = {
+  choiceIDs: [],
+  text: "",
+  otherSelected: false,
+  other: "",
+};
+
+/** プルダウンで「その他」を表すsentinel。choiceIDと衝突しない値にする */
+const OTHER_VALUE = "__other__";
+
+const isChoiceQuestion = (question: Question): boolean =>
+  question.type === "single_choice" ||
+  question.type === "dropdown" ||
+  question.type === "multi_choice";
+
+/** 「その他」が選ばれていて、かつ自由記述が埋まっているか */
+const hasOtherAnswer = (question: Question, answer: AnswerDraft): boolean =>
+  question.allowOther && answer.otherSelected && answer.other.trim() !== "";
 
 const isAnswered = (question: Question, answer: AnswerDraft): boolean => {
-  switch (question.type) {
+  if (isChoiceQuestion(question)) {
+    return answer.choiceIDs.length > 0 || hasOtherAnswer(question, answer);
+  }
+  return answer.text.trim() !== "";
+};
+
+const sortedChoices = (question: Question) =>
+  [...question.choices].sort((a, b) => a.displayOrder - b.displayOrder);
+
+type FieldProps = {
+  question: Question;
+  answer: AnswerDraft;
+  onChange: (patch: Partial<AnswerDraft>) => void;
+};
+
+const SingleChoiceField = ({ question, answer, onChange }: FieldProps) => (
+  <div>
+    {sortedChoices(question).map((choice) => (
+      <label
+        key={choice.choiceID}
+        className="flex h-12 cursor-pointer items-center"
+      >
+        <input
+          type="radio"
+          name={question.questionID}
+          className="mx-3 size-5 shrink-0 cursor-pointer accent-cs-pass"
+          checked={
+            !answer.otherSelected && answer.choiceIDs[0] === choice.choiceID
+          }
+          onChange={() => {
+            onChange({ choiceIDs: [choice.choiceID], otherSelected: false });
+          }}
+        />
+        <span>{choice.text}</span>
+      </label>
+    ))}
+    {question.allowOther && (
+      <label className="flex h-12 cursor-pointer items-center">
+        <input
+          type="radio"
+          name={question.questionID}
+          className="mx-3 size-5 shrink-0 cursor-pointer accent-cs-pass"
+          checked={answer.otherSelected}
+          onChange={() => {
+            onChange({ choiceIDs: [], otherSelected: true });
+          }}
+        />
+        <span>その他</span>
+      </label>
+    )}
+  </div>
+);
+
+const MultiChoiceField = ({ question, answer, onChange }: FieldProps) => (
+  <div className="space-y-2 px-3">
+    {sortedChoices(question).map((choice) => (
+      <Checkbox
+        key={choice.choiceID}
+        id={`${question.questionID}-${choice.choiceID}`}
+        label={choice.text}
+        checked={answer.choiceIDs.includes(choice.choiceID)}
+        onChange={(e) => {
+          onChange({
+            choiceIDs: e.currentTarget.checked
+              ? [...answer.choiceIDs, choice.choiceID]
+              : answer.choiceIDs.filter((id) => id !== choice.choiceID),
+          });
+        }}
+      />
+    ))}
+    {question.allowOther && (
+      <Checkbox
+        id={`${question.questionID}-other`}
+        label="その他"
+        checked={answer.otherSelected}
+        onChange={(e) => {
+          onChange({ otherSelected: e.currentTarget.checked });
+        }}
+      />
+    )}
+  </div>
+);
+
+const DropdownField = ({ question, answer, onChange }: FieldProps) => (
+  <Select
+    options={[
+      ...sortedChoices(question).map((choice) => ({
+        value: choice.choiceID,
+        title: choice.text,
+      })),
+      ...(question.allowOther ? [{ value: OTHER_VALUE, title: "その他" }] : []),
+    ]}
+    value={answer.otherSelected ? OTHER_VALUE : answer.choiceIDs[0] || ""}
+    onChange={(e) => {
+      const value = e.currentTarget.value;
+      onChange({
+        choiceIDs: value && value !== OTHER_VALUE ? [value] : [],
+        otherSelected: value === OTHER_VALUE,
+      });
+    }}
+    aria-label={question.text}
+  />
+);
+
+const RatingField = ({ question, answer, onChange }: FieldProps) => {
+  const min = question.minValue ?? 1;
+  const max = question.maxValue ?? 5;
+
+  const toTitle = (value: number) => {
+    if (value === min && question.minLabel) {
+      return `${value}：${question.minLabel}`;
+    }
+    if (value === max && question.maxLabel) {
+      return `${value}：${question.maxLabel}`;
+    }
+    return `${value}`;
+  };
+
+  return (
+    <Select
+      options={Array.from({ length: max - min + 1 }, (_, i) => {
+        const value = min + i;
+        return { value: `${value}`, title: toTitle(value) };
+      })}
+      value={answer.text}
+      onChange={(e) => {
+        onChange({ text: e.currentTarget.value });
+      }}
+      aria-label={question.text}
+    />
+  );
+};
+
+const DateField = ({ question, answer, onChange }: FieldProps) => (
+  <Input
+    type="date"
+    className="px-4"
+    value={answer.text}
+    onChange={(e) => {
+      onChange({ text: e.currentTarget.value });
+    }}
+    aria-label={question.text}
+  />
+);
+
+const FreeTextField = ({ question, answer, onChange }: FieldProps) => (
+  <Textarea
+    rows={3}
+    maxLength={question.maxLength ?? undefined}
+    placeholder="回答を入力"
+    value={answer.text}
+    onChange={(e) => {
+      onChange({ text: e.currentTarget.value });
+    }}
+    aria-label={question.text}
+  />
+);
+
+const QuestionField = (props: FieldProps) => {
+  switch (props.question.type) {
     case "single_choice":
-    case "dropdown":
+      return <SingleChoiceField {...props} />;
     case "multi_choice":
-      return answer.choiceIDs.length > 0;
+      return <MultiChoiceField {...props} />;
+    case "dropdown":
+      return <DropdownField {...props} />;
+    case "rating":
+      return <RatingField {...props} />;
+    case "date":
+      return <DateField {...props} />;
     default:
-      return answer.text.trim() !== "";
+      return <FreeTextField {...props} />;
   }
 };
+
+const QuestionItem = ({
+  question,
+  answer,
+  index,
+  onChange,
+}: FieldProps & { index: number }) => (
+  <div className="space-y-2">
+    <p className="font-bold">
+      {index + 1}.{question.text}
+      <span
+        className={`ml-2 rounded px-1 py-0.5 font-medium text-xs ${
+          question.isRequired
+            ? "bg-cs-caution text-white"
+            : "bg-cs-gray-200 text-cs-gray-600"
+        }`}
+      >
+        {question.isRequired ? "必須" : "任意"}
+      </span>
+    </p>
+    <QuestionField question={question} answer={answer} onChange={onChange} />
+    {isChoiceQuestion(question) &&
+      question.allowOther &&
+      answer.otherSelected && (
+        <Input
+          type="text"
+          className="px-4"
+          maxLength={question.maxLength ?? undefined}
+          placeholder="その他の内容を入力"
+          value={answer.other}
+          onChange={(e) => {
+            onChange({ other: e.currentTarget.value });
+          }}
+          aria-label={`${question.text}のその他`}
+        />
+      )}
+  </div>
+);
 
 type Props = {
   sessionID: string;
@@ -89,6 +314,9 @@ export const SurveyModalContent = ({
               return {
                 questionID: question.questionID,
                 selectedChoiceIDs: answer.choiceIDs,
+                ...(hasOtherAnswer(question, answer)
+                  ? { other: answer.other.trim() }
+                  : {}),
               };
             case "rating":
               return {
@@ -137,132 +365,6 @@ export const SurveyModalContent = ({
     onAnswered();
   };
 
-  const renderQuestion = (question: Question, index: number) => {
-    const answer = getAnswer(question.questionID);
-    const choices = [...question.choices].sort(
-      (a, b) => a.displayOrder - b.displayOrder,
-    );
-
-    return (
-      <div key={question.questionID} className="space-y-2">
-        <p className="font-bold">
-          {index + 1}.{question.text}
-        </p>
-        {question.type === "single_choice" && (
-          <div>
-            {choices.map((choice) => (
-              <label
-                key={choice.choiceID}
-                className="flex h-12 cursor-pointer items-center"
-              >
-                <input
-                  type="radio"
-                  name={question.questionID}
-                  className="mx-3 size-5 shrink-0 cursor-pointer accent-cs-pass"
-                  checked={answer.choiceIDs[0] === choice.choiceID}
-                  onChange={() => {
-                    updateAnswer(question.questionID, {
-                      choiceIDs: [choice.choiceID],
-                    });
-                  }}
-                />
-                <span>{choice.text}</span>
-              </label>
-            ))}
-          </div>
-        )}
-        {question.type === "multi_choice" && (
-          <div className="space-y-2 px-3">
-            {choices.map((choice) => (
-              <Checkbox
-                key={choice.choiceID}
-                id={`${question.questionID}-${choice.choiceID}`}
-                label={choice.text}
-                checked={answer.choiceIDs.includes(choice.choiceID)}
-                onChange={(e) => {
-                  const checked = e.currentTarget.checked;
-                  updateAnswer(question.questionID, {
-                    choiceIDs: checked
-                      ? [...answer.choiceIDs, choice.choiceID]
-                      : answer.choiceIDs.filter((id) => id !== choice.choiceID),
-                  });
-                }}
-              />
-            ))}
-          </div>
-        )}
-        {question.type === "dropdown" && (
-          <Select
-            options={choices.map((choice) => ({
-              value: choice.choiceID,
-              title: choice.text,
-            }))}
-            value={answer.choiceIDs[0] || ""}
-            onChange={(e) => {
-              updateAnswer(question.questionID, {
-                choiceIDs: e.currentTarget.value ? [e.currentTarget.value] : [],
-              });
-            }}
-            aria-label={question.text}
-          />
-        )}
-        {question.type === "rating" && (
-          <Select
-            options={Array.from(
-              {
-                length: (question.maxValue ?? 5) - (question.minValue ?? 1) + 1,
-              },
-              (_, i) => {
-                const value = (question.minValue ?? 1) + i;
-                const label =
-                  value === (question.minValue ?? 1) && question.minLabel
-                    ? `${value}：${question.minLabel}`
-                    : value === (question.maxValue ?? 5) && question.maxLabel
-                      ? `${value}：${question.maxLabel}`
-                      : `${value}`;
-                return { value: `${value}`, title: label };
-              },
-            )}
-            value={answer.text}
-            onChange={(e) => {
-              updateAnswer(question.questionID, {
-                text: e.currentTarget.value,
-              });
-            }}
-            aria-label={question.text}
-          />
-        )}
-        {question.type === "date" && (
-          <Input
-            type="date"
-            className="px-4"
-            value={answer.text}
-            onChange={(e) => {
-              updateAnswer(question.questionID, {
-                text: e.currentTarget.value,
-              });
-            }}
-            aria-label={question.text}
-          />
-        )}
-        {question.type === "free_text" && (
-          <Textarea
-            rows={3}
-            maxLength={question.maxLength ?? undefined}
-            placeholder="回答を入力"
-            value={answer.text}
-            onChange={(e) => {
-              updateAnswer(question.questionID, {
-                text: e.currentTarget.value,
-              });
-            }}
-            aria-label={question.text}
-          />
-        )}
-      </div>
-    );
-  };
-
   return (
     <div className="w-[327px] p-2">
       <p className="font-bold text-[18px]">アンケート回答のお願い</p>
@@ -275,7 +377,15 @@ export const SurveyModalContent = ({
       <hr className="mt-2 border-gray-300" />
       <SimpleBar style={{ maxHeight: 320 }} className="mt-2" autoHide={false}>
         <div className="space-y-4 pr-3">
-          {questions.map((question, i) => renderQuestion(question, i))}
+          {questions.map((question, i) => (
+            <QuestionItem
+              key={question.questionID}
+              question={question}
+              answer={getAnswer(question.questionID)}
+              index={i}
+              onChange={(patch) => updateAnswer(question.questionID, patch)}
+            />
+          ))}
         </div>
       </SimpleBar>
       <div className="mt-4 flex gap-4">

--- a/app/routes/_pages.make.$session_id._index/components/SurveyEditor/index.tsx
+++ b/app/routes/_pages.make.$session_id._index/components/SurveyEditor/index.tsx
@@ -1,26 +1,182 @@
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { Input } from "~/components/ui/input";
 import { CenterDialog } from "~/components/ui/modal";
 import { Switch } from "~/components/ui/switch";
 import type { SurveyQuestionDraft, SurveyQuestionType } from "../../types";
 
+/**
+ * 選択肢を持つ質問タイプ。ここに含まれないタイプはchoicesを送らない
+ */
+export const CHOICE_QUESTION_TYPES = [
+  "single_choice",
+  "multi_choice",
+  "dropdown",
+] as const;
+
+export const isChoiceQuestion = (type: SurveyQuestionType): boolean =>
+  (CHOICE_QUESTION_TYPES as readonly SurveyQuestionType[]).includes(type);
+
+/** 自由記述の入力欄を持つか。maxLengthはこの場合だけ意味を持つ */
+const hasFreeTextInput = (question: SurveyQuestionDraft): boolean =>
+  question.type === "free_text" ||
+  (isChoiceQuestion(question.type) && question.allowOther);
+
 export const MAX_CHOICES: Record<SurveyQuestionType, number> = {
   single_choice: 5,
+  multi_choice: 10,
   dropdown: 10,
+  free_text: 0,
+  rating: 0,
+  date: 0,
 };
 
 export const MIN_CHOICES = 2;
 
+/** 自由記述（free_text・その他）の最大文字数として設定できる上限 */
+export const MAX_TEXT_LENGTH = 1000;
+
+/** ratingの下限・上限として設定できる範囲。回答側はこの範囲をプルダウンで列挙する */
+export const RATING_MIN = 0;
+export const RATING_MAX = 10;
+export const RATING_MAX_SPAN = 10;
+
 const QUESTION_TYPE_LABELS: Record<SurveyQuestionType, string> = {
   single_choice: "ラジオボタン",
+  multi_choice: "チェックボックス",
   dropdown: "プルダウン",
+  free_text: "自由記述",
+  rating: "評価（数値）",
+  date: "日付",
 };
+
+const QUESTION_TYPE_OPTIONS = Object.keys(
+  QUESTION_TYPE_LABELS,
+) as SurveyQuestionType[];
 
 export const createEmptyQuestion = (): SurveyQuestionDraft => ({
   text: "",
   type: "single_choice",
+  isRequired: true,
+  allowOther: false,
+  containsPii: false,
+  maxLength: null,
+  minValue: null,
+  maxValue: null,
+  minLabel: null,
+  maxLabel: null,
   choices: [{ text: "" }, { text: "" }],
 });
+
+/**
+ * 質問タイプを変更したときに、そのタイプで意味を持たない設定を落とす。
+ * 選択肢は選択肢系タイプの間では引き継ぎ、それ以外に変えたら空にする
+ */
+const applyQuestionType = (
+  question: SurveyQuestionDraft,
+  type: SurveyQuestionType,
+): SurveyQuestionDraft => {
+  const choices = isChoiceQuestion(type)
+    ? question.choices.length > 0
+      ? question.choices.slice(0, MAX_CHOICES[type])
+      : [{ text: "" }, { text: "" }]
+    : [];
+
+  return {
+    ...question,
+    type,
+    choices,
+    allowOther: isChoiceQuestion(type) ? question.allowOther : false,
+    maxLength:
+      type === "free_text" || (isChoiceQuestion(type) && question.allowOther)
+        ? question.maxLength
+        : null,
+    minValue: type === "rating" ? (question.minValue ?? 1) : null,
+    maxValue: type === "rating" ? (question.maxValue ?? 5) : null,
+    minLabel: type === "rating" ? question.minLabel : null,
+    maxLabel: type === "rating" ? question.maxLabel : null,
+  };
+};
+
+const validateChoices = (
+  question: SurveyQuestionDraft,
+  label: string,
+): string | null => {
+  if (question.choices.length < MIN_CHOICES) {
+    return `${label}の項目は${MIN_CHOICES}つ以上必要です`;
+  }
+  if (question.choices.length > MAX_CHOICES[question.type]) {
+    return `${label}の項目は${QUESTION_TYPE_LABELS[question.type]}の場合最大${MAX_CHOICES[question.type]}つまでです`;
+  }
+  if (question.choices.some((choice) => choice.text.trim() === "")) {
+    return `${label}の項目をすべて入力してください`;
+  }
+  return null;
+};
+
+const validateRating = (
+  question: SurveyQuestionDraft,
+  label: string,
+): string | null => {
+  const { minValue: min, maxValue: max } = question;
+  if (min === null || max === null) {
+    return `${label}の下限値と上限値を入力してください`;
+  }
+  if (!(Number.isInteger(min) && Number.isInteger(max))) {
+    return `${label}の下限値と上限値は整数で入力してください`;
+  }
+  if (min < RATING_MIN || max > RATING_MAX) {
+    return `${label}の評価は${RATING_MIN}〜${RATING_MAX}の範囲で設定してください`;
+  }
+  if (min >= max) {
+    return `${label}の上限値は下限値より大きくしてください`;
+  }
+  if (max - min > RATING_MAX_SPAN) {
+    return `${label}の評価の幅は${RATING_MAX_SPAN}までにしてください`;
+  }
+  return null;
+};
+
+const validateMaxLength = (
+  question: SurveyQuestionDraft,
+  label: string,
+): string | null => {
+  const { maxLength } = question;
+  if (maxLength === null) {
+    return null;
+  }
+  if (!Number.isInteger(maxLength) || maxLength < 1) {
+    return `${label}の最大文字数は1以上の整数で入力してください`;
+  }
+  if (maxLength > MAX_TEXT_LENGTH) {
+    return `${label}の最大文字数は${MAX_TEXT_LENGTH}以下にしてください`;
+  }
+  return null;
+};
+
+const validateSurveyQuestion = (
+  question: SurveyQuestionDraft,
+  label: string,
+): string | null => {
+  if (question.text.trim() === "") {
+    return `${label}の質問文を入力してください`;
+  }
+  if (isChoiceQuestion(question.type)) {
+    const error = validateChoices(question, label);
+    if (error) {
+      return error;
+    }
+  }
+  if (question.type === "rating") {
+    const error = validateRating(question, label);
+    if (error) {
+      return error;
+    }
+  }
+  if (hasFreeTextInput(question)) {
+    return validateMaxLength(question, label);
+  }
+  return null;
+};
 
 export const validateSurveyQuestions = (
   questions: SurveyQuestionDraft[],
@@ -29,18 +185,9 @@ export const validateSurveyQuestions = (
     return "アンケートの質問を1つ以上追加してください";
   }
   for (const [i, question] of questions.entries()) {
-    const label = `質問${i + 1}`;
-    if (question.text.trim() === "") {
-      return `${label}の質問文を入力してください`;
-    }
-    if (question.choices.length < MIN_CHOICES) {
-      return `${label}の項目は${MIN_CHOICES}つ以上必要です`;
-    }
-    if (question.choices.length > MAX_CHOICES[question.type]) {
-      return `${label}の項目は${QUESTION_TYPE_LABELS[question.type]}の場合最大${MAX_CHOICES[question.type]}つまでです`;
-    }
-    if (question.choices.some((choice) => choice.text.trim() === "")) {
-      return `${label}の項目をすべて入力してください`;
+    const error = validateSurveyQuestion(question, `質問${i + 1}`);
+    if (error) {
+      return error;
     }
   }
   return null;
@@ -66,6 +213,117 @@ const TrashIcon = () => (
   </svg>
 );
 
+/** 数値入力。空文字はnullとして扱う */
+const toNumberOrNull = (value: string): number | null => {
+  if (value.trim() === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+/** 空文字はnullとして扱う（APIのnullableな文字列項目に合わせる） */
+const toTextOrNull = (value: string): string | null =>
+  value.trim() === "" ? null : value;
+
+type FieldProps = {
+  label: string;
+  children: ReactNode;
+};
+
+/**
+ * Inputは独自コンポーネントでlabel紐付けができないため、
+ * 見出しはspanで置きaria-label側で読み上げを担保する
+ */
+const Field = ({ label, children }: FieldProps) => (
+  <div className="space-y-1">
+    <span className="block text-cs-gray-600 text-xs">{label}</span>
+    {children}
+  </div>
+);
+
+type RatingSettingsProps = {
+  question: SurveyQuestionDraft;
+  questionNumber: number;
+  onChange: (patch: Partial<SurveyQuestionDraft>) => void;
+};
+
+const RatingSettings = ({
+  question,
+  questionNumber,
+  onChange,
+}: RatingSettingsProps) => (
+  <div className="grid grid-cols-2 gap-2">
+    <Field label="下限値">
+      <Input
+        type="number"
+        className="h-10"
+        min={RATING_MIN}
+        max={RATING_MAX}
+        value={question.minValue ?? ""}
+        onChange={(e) => {
+          onChange({ minValue: toNumberOrNull(e.currentTarget.value) });
+        }}
+        aria-label={`質問${questionNumber}の下限値`}
+      />
+    </Field>
+    <Field label="上限値">
+      <Input
+        type="number"
+        className="h-10"
+        min={RATING_MIN}
+        max={RATING_MAX}
+        value={question.maxValue ?? ""}
+        onChange={(e) => {
+          onChange({ maxValue: toNumberOrNull(e.currentTarget.value) });
+        }}
+        aria-label={`質問${questionNumber}の上限値`}
+      />
+    </Field>
+    <Field label="下限のラベル（任意）">
+      <Input
+        type="text"
+        className="h-10"
+        placeholder="全く満足していない"
+        value={question.minLabel ?? ""}
+        onChange={(e) => {
+          onChange({ minLabel: toTextOrNull(e.currentTarget.value) });
+        }}
+        aria-label={`質問${questionNumber}の下限のラベル`}
+      />
+    </Field>
+    <Field label="上限のラベル（任意）">
+      <Input
+        type="text"
+        className="h-10"
+        placeholder="非常に満足している"
+        value={question.maxLabel ?? ""}
+        onChange={(e) => {
+          onChange({ maxLabel: toTextOrNull(e.currentTarget.value) });
+        }}
+        aria-label={`質問${questionNumber}の上限のラベル`}
+      />
+    </Field>
+  </div>
+);
+
+type SettingRowProps = {
+  label: string;
+  note?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+};
+
+const SettingRow = ({ label, note, checked, onChange }: SettingRowProps) => (
+  <div className="flex items-center justify-between gap-2">
+    <span className="text-sm">
+      {label}
+      {note && <span className="block text-cs-gray-600 text-xs">{note}</span>}
+    </span>
+    <Switch checked={checked} onChange={onChange} aria-label={label} />
+  </div>
+);
+
 type Props = {
   enabled: boolean;
   onEnabledChange: (enabled: boolean) => void;
@@ -87,6 +345,12 @@ export const SurveyEditor = ({
   ) => {
     onQuestionsChange(
       questions.map((q, i) => (i === index ? { ...q, ...patch } : q)),
+    );
+  };
+
+  const changeQuestionType = (index: number, type: SurveyQuestionType) => {
+    onQuestionsChange(
+      questions.map((q, i) => (i === index ? applyQuestionType(q, type) : q)),
     );
   };
 
@@ -133,18 +397,18 @@ export const SurveyEditor = ({
                   className="h-10 rounded-md border border-gray-300 bg-white px-2 text-sm"
                   value={question.type}
                   onChange={(e) => {
-                    updateQuestion(questionIndex, {
-                      type: e.currentTarget.value as SurveyQuestionType,
-                    });
+                    changeQuestionType(
+                      questionIndex,
+                      e.currentTarget.value as SurveyQuestionType,
+                    );
                   }}
                   aria-label={`質問${questionIndex + 1}の質問形式`}
                 >
-                  <option value="single_choice">
-                    {QUESTION_TYPE_LABELS.single_choice}
-                  </option>
-                  <option value="dropdown">
-                    {QUESTION_TYPE_LABELS.dropdown}
-                  </option>
+                  {QUESTION_TYPE_OPTIONS.map((type) => (
+                    <option key={type} value={type}>
+                      {QUESTION_TYPE_LABELS[type]}
+                    </option>
+                  ))}
                 </select>
               </div>
               <div className="flex items-center gap-1">
@@ -168,50 +432,115 @@ export const SurveyEditor = ({
                   <TrashIcon />
                 </button>
               </div>
-              {question.choices.map((choice, choiceIndex) => (
-                <div key={choiceIndex} className="flex items-center gap-1">
-                  <span className="flex size-10 shrink-0 items-center justify-center text-cs-gray-600">
-                    {question.type === "single_choice" ? (
-                      <span className="size-5 rounded-full border-2 border-cs-gray-500" />
-                    ) : (
-                      <span className="text-sm">{choiceIndex + 1}.</span>
-                    )}
-                  </span>
-                  <Input
-                    type="text"
-                    value={choice.text}
-                    onChange={(e) => {
-                      const text = e.currentTarget.value;
-                      updateQuestion(questionIndex, {
-                        choices: question.choices.map((c, i) =>
-                          i === choiceIndex ? { ...c, text } : c,
-                        ),
-                      });
-                    }}
-                    placeholder="項目を入力"
-                    aria-label={`質問${questionIndex + 1}の項目${choiceIndex + 1}`}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => removeChoice(questionIndex, choiceIndex)}
-                    className="flex size-10 shrink-0 cursor-pointer items-center justify-center text-cs-caution"
-                    aria-label={`質問${questionIndex + 1}の項目${choiceIndex + 1}を削除`}
-                  >
-                    <TrashIcon />
-                  </button>
-                </div>
-              ))}
-              {question.choices.length < MAX_CHOICES[question.type] && (
-                <div className="pr-11 pl-11">
-                  <button
-                    type="button"
-                    onClick={() => addChoice(questionIndex)}
-                    className="h-10 w-full cursor-pointer rounded-md bg-cs-gray-200 text-sm"
-                  >
-                    ＋ 項目を追加
-                  </button>
-                </div>
+
+              {isChoiceQuestion(question.type) && (
+                <>
+                  {question.choices.map((choice, choiceIndex) => (
+                    <div key={choiceIndex} className="flex items-center gap-1">
+                      <span className="flex size-10 shrink-0 items-center justify-center text-cs-gray-600">
+                        {question.type === "single_choice" ? (
+                          <span className="size-5 rounded-full border-2 border-cs-gray-500" />
+                        ) : question.type === "multi_choice" ? (
+                          <span className="size-5 rounded border-2 border-cs-gray-500" />
+                        ) : (
+                          <span className="text-sm">{choiceIndex + 1}.</span>
+                        )}
+                      </span>
+                      <Input
+                        type="text"
+                        value={choice.text}
+                        onChange={(e) => {
+                          const text = e.currentTarget.value;
+                          updateQuestion(questionIndex, {
+                            choices: question.choices.map((c, i) =>
+                              i === choiceIndex ? { ...c, text } : c,
+                            ),
+                          });
+                        }}
+                        placeholder="項目を入力"
+                        aria-label={`質問${questionIndex + 1}の項目${choiceIndex + 1}`}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeChoice(questionIndex, choiceIndex)}
+                        className="flex size-10 shrink-0 cursor-pointer items-center justify-center text-cs-caution"
+                        aria-label={`質問${questionIndex + 1}の項目${choiceIndex + 1}を削除`}
+                      >
+                        <TrashIcon />
+                      </button>
+                    </div>
+                  ))}
+                  {question.choices.length < MAX_CHOICES[question.type] && (
+                    <div className="pr-11 pl-11">
+                      <button
+                        type="button"
+                        onClick={() => addChoice(questionIndex)}
+                        className="h-10 w-full cursor-pointer rounded-md bg-cs-gray-200 text-sm"
+                      >
+                        ＋ 項目を追加
+                      </button>
+                    </div>
+                  )}
+                </>
               )}
+
+              {question.type === "rating" && (
+                <RatingSettings
+                  question={question}
+                  questionNumber={questionIndex + 1}
+                  onChange={(patch) => updateQuestion(questionIndex, patch)}
+                />
+              )}
+
+              <div className="space-y-2 rounded-md bg-cs-gray-200 p-3">
+                <SettingRow
+                  label="回答を必須にする"
+                  checked={question.isRequired}
+                  onChange={(isRequired) =>
+                    updateQuestion(questionIndex, { isRequired })
+                  }
+                />
+                {isChoiceQuestion(question.type) && (
+                  <SettingRow
+                    label="「その他」の自由記述を許可する"
+                    checked={question.allowOther}
+                    onChange={(allowOther) =>
+                      updateQuestion(questionIndex, {
+                        allowOther,
+                        // 自由記述がなくなるなら文字数制限も落とす
+                        maxLength: allowOther ? question.maxLength : null,
+                      })
+                    }
+                  />
+                )}
+                {hasFreeTextInput(question) && (
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm">最大文字数（任意）</span>
+                    <Input
+                      type="number"
+                      className="h-10 w-24"
+                      min={1}
+                      max={MAX_TEXT_LENGTH}
+                      placeholder="制限なし"
+                      value={question.maxLength ?? ""}
+                      onChange={(e) => {
+                        updateQuestion(questionIndex, {
+                          maxLength: toNumberOrNull(e.currentTarget.value),
+                        });
+                      }}
+                      aria-label={`質問${questionIndex + 1}の最大文字数`}
+                    />
+                  </div>
+                )}
+                <SettingRow
+                  label="個人情報を含む質問"
+                  note="回答を暗号化して保存します"
+                  checked={question.containsPii}
+                  onChange={(containsPii) =>
+                    updateQuestion(questionIndex, { containsPii })
+                  }
+                />
+              </div>
             </div>
           ))}
           <hr className="border-gray-300" />

--- a/app/routes/_pages.make.$session_id._index/components/SurveyEditor/index.tsx
+++ b/app/routes/_pages.make.$session_id._index/components/SurveyEditor/index.tsx
@@ -310,17 +310,29 @@ const RatingSettings = ({
 type SettingRowProps = {
   label: string;
   note?: string;
+  /** 同じラベルが質問ごとに並ぶため、読み上げ名は質問番号で修飾する */
+  questionNumber: number;
   checked: boolean;
   onChange: (checked: boolean) => void;
 };
 
-const SettingRow = ({ label, note, checked, onChange }: SettingRowProps) => (
+const SettingRow = ({
+  label,
+  note,
+  questionNumber,
+  checked,
+  onChange,
+}: SettingRowProps) => (
   <div className="flex items-center justify-between gap-2">
     <span className="text-sm">
       {label}
       {note && <span className="block text-cs-gray-600 text-xs">{note}</span>}
     </span>
-    <Switch checked={checked} onChange={onChange} aria-label={label} />
+    <Switch
+      checked={checked}
+      onChange={onChange}
+      aria-label={`質問${questionNumber}の${label}`}
+    />
   </div>
 );
 
@@ -495,6 +507,7 @@ export const SurveyEditor = ({
               <div className="space-y-2 rounded-md bg-cs-gray-200 p-3">
                 <SettingRow
                   label="回答を必須にする"
+                  questionNumber={questionIndex + 1}
                   checked={question.isRequired}
                   onChange={(isRequired) =>
                     updateQuestion(questionIndex, { isRequired })
@@ -503,6 +516,7 @@ export const SurveyEditor = ({
                 {isChoiceQuestion(question.type) && (
                   <SettingRow
                     label="「その他」の自由記述を許可する"
+                    questionNumber={questionIndex + 1}
                     checked={question.allowOther}
                     onChange={(allowOther) =>
                       updateQuestion(questionIndex, {
@@ -535,6 +549,7 @@ export const SurveyEditor = ({
                 <SettingRow
                   label="個人情報を含む質問"
                   note="回答を暗号化して保存します"
+                  questionNumber={questionIndex + 1}
                   checked={question.containsPii}
                   onChange={(containsPii) =>
                     updateQuestion(questionIndex, { containsPii })

--- a/app/routes/_pages.make.$session_id._index/index.tsx
+++ b/app/routes/_pages.make.$session_id._index/index.tsx
@@ -97,7 +97,11 @@ export default function Page({
   const thumbnailRef = useRef<string>(null);
   const navigate = useNavigate();
 
-  const saveSurvey = async (talkSessionID: string): Promise<boolean> => {
+  /** 通信自体が失敗した場合も呼び出し元でエラー表示できるようfalseに倒す */
+  const saveSurvey = (talkSessionID: string): Promise<boolean> =>
+    saveSurveyRequest(talkSessionID).catch(() => false);
+
+  const saveSurveyRequest = async (talkSessionID: string): Promise<boolean> => {
     if (!survey) {
       if (!isSurveyEnabled) {
         return true;

--- a/app/routes/_pages.make.$session_id._index/index.tsx
+++ b/app/routes/_pages.make.$session_id._index/index.tsx
@@ -23,6 +23,7 @@ import { isFieldsError } from "~/utils/form";
 import {
   SurveyEditor,
   createEmptyQuestion,
+  isChoiceQuestion,
   validateSurveyQuestions,
 } from "./components/SurveyEditor";
 import { createSessionFormSchema } from "./schemas";
@@ -37,15 +38,51 @@ const toSurveyQuestionInputs = (questions: SurveyQuestionDraft[]) =>
     questionID: question.questionID,
     text: question.text.trim(),
     type: question.type,
-    isRequired: true,
-    allowOther: false,
+    isRequired: question.isRequired,
+    allowOther: question.allowOther,
+    containsPii: question.containsPii,
+    maxLength: question.maxLength,
+    minValue: question.minValue,
+    maxValue: question.maxValue,
+    minLabel: question.minLabel,
+    maxLabel: question.maxLabel,
     displayOrder: questionIndex,
-    choices: question.choices.map((choice, choiceIndex) => ({
-      choiceID: choice.choiceID,
-      text: choice.text.trim(),
-      displayOrder: choiceIndex,
-    })),
+    // 選択肢を持たないタイプでは空配列を送る
+    choices: isChoiceQuestion(question.type)
+      ? question.choices.map((choice, choiceIndex) => ({
+          choiceID: choice.choiceID,
+          text: choice.text.trim(),
+          displayOrder: choiceIndex,
+        }))
+      : [],
   }));
+
+const toSurveyQuestionDrafts = (
+  questions: NonNullable<
+    Route.ComponentProps["loaderData"]["survey"]
+  >["questions"],
+): SurveyQuestionDraft[] =>
+  [...questions]
+    .sort((a, b) => a.displayOrder - b.displayOrder)
+    .map((question) => ({
+      questionID: question.questionID,
+      text: question.text,
+      type: question.type,
+      isRequired: question.isRequired,
+      allowOther: question.allowOther,
+      containsPii: question.containsPii,
+      maxLength: question.maxLength ?? null,
+      minValue: question.minValue ?? null,
+      maxValue: question.maxValue ?? null,
+      minLabel: question.minLabel ?? null,
+      maxLabel: question.maxLabel ?? null,
+      choices: [...question.choices]
+        .sort((a, b) => a.displayOrder - b.displayOrder)
+        .map((choice) => ({
+          choiceID: choice.choiceID,
+          text: choice.text,
+        })),
+    }));
 
 export default function Page({
   loaderData: { session, isEditMode, survey },
@@ -54,19 +91,7 @@ export default function Page({
   const [surveyQuestions, setSurveyQuestions] = useState<SurveyQuestionDraft[]>(
     () =>
       survey && survey.questions.length > 0
-        ? [...survey.questions]
-            .sort((a, b) => a.displayOrder - b.displayOrder)
-            .map((question) => ({
-              questionID: question.questionID,
-              text: question.text,
-              type: question.type === "dropdown" ? "dropdown" : "single_choice",
-              choices: [...question.choices]
-                .sort((a, b) => a.displayOrder - b.displayOrder)
-                .map((choice) => ({
-                  choiceID: choice.choiceID,
-                  text: choice.text,
-                })),
-            }))
+        ? toSurveyQuestionDrafts(survey.questions)
         : [createEmptyQuestion()],
   );
   const thumbnailRef = useRef<string>(null);

--- a/app/routes/_pages.make.$session_id._index/types/index.ts
+++ b/app/routes/_pages.make.$session_id._index/types/index.ts
@@ -3,7 +3,10 @@ export type PrefectureCity = {
   city: string;
 };
 
-export type SurveyQuestionType = "single_choice" | "dropdown";
+import type { components } from "~/types/openapi";
+
+export type SurveyQuestionType =
+  components["schemas"]["TalkSessionSurveyQuestionType"];
 
 export type SurveyChoiceDraft = {
   choiceID?: string;
@@ -14,5 +17,17 @@ export type SurveyQuestionDraft = {
   questionID?: string;
   text: string;
   type: SurveyQuestionType;
+  isRequired: boolean;
+  /** 「その他」自由記述を許可するか。選択肢系のみ有効 */
+  allowOther: boolean;
+  /** 個人情報を含む設問か。trueならAPI側で回答が暗号化される */
+  containsPii: boolean;
+  /** free_text / その他 の最大文字数。未設定はnull */
+  maxLength: number | null;
+  /** rating の下限値・上限値とそのラベル */
+  minValue: number | null;
+  maxValue: number | null;
+  minLabel: string | null;
+  maxLabel: string | null;
   choices: SurveyChoiceDraft[];
 };


### PR DESCRIPTION
## 概要

アンケート機能の作成側（エディタ）が API 仕様に追いついていなかったため、追従させました。

作成側は `single_choice` / `dropdown` の2タイプしか作れず、`isRequired` は `true`、`allowOther` は `false` にハードコードされていました。一方で回答モーダルは6タイプすべてをレンダリングできる実装になっており、API 側だけが先行している状態でした。

集計表示（`GET /talksessions/{talkSessionID}/survey/summary`）は今回のスコープ外です。オーナーが回答結果を見る手段は引き続きありません。

## 変更内容

### 作成側（`app/routes/_pages.make.$session_id._index/`）

- **質問タイプを6種に拡張**：`multi_choice`（チェックボックス）・`rating`（評価）・`date`（日付）・`free_text`（自由記述）を追加。`SurveyQuestionType` は手書きの union をやめ、生成型 `TalkSessionSurveyQuestionType` を参照するように変更
- **質問ごとの設定を追加**：必須回答（`isRequired`）、「その他」の自由記述を許可（`allowOther`）、個人情報を含む質問（`containsPii`）、最大文字数（`maxLength`）、rating の下限値/上限値とラベル（`minValue` / `maxValue` / `minLabel` / `maxLabel`）
- **タイプ変更時の整合性**：`applyQuestionType()` で、そのタイプで意味を持たない項目を落とす。選択肢は選択肢系タイプ間で引き継ぎ（新しい上限で切り詰め）、非選択肢系に変えたら空にする。既存アンケート編集時は、こぼれた選択肢が既存の差分計算で `deletedChoiceIDs` に乗る
- **バリデーション追加**：rating は整数・0〜10の範囲・下限 < 上限・幅10以内、`maxLength` は1〜1000
- 選択肢の上限は `single_choice` = 5、`multi_choice` / `dropdown` = 10

### 回答側（`app/routes/_pages.$session_id/.../SurveyModalContent/`）

- **`other`（その他の自由記述）に対応**：これまで `allowOther` を無視していたため、オーナーが許可しても参加者が入力できませんでした。`single_choice` はラジオ、`multi_choice` はチェックボックス、`dropdown` は選択肢に「その他」を追加し、選択時に自由記述欄（`maxLength` 適用）を表示して `other` を送信します。必須判定（`canSubmit`）も「その他が選択済みかつ入力あり」を回答済みとして数えます
- **必須/任意バッジを表示**：`isRequired` が設定可能になったため

### リファクタ

biome の `noExcessiveCognitiveComplexity` / `noLabelWithoutControl` に引っかかったため、以下を分割しました。

- `validateSurveyQuestions` を種別ごとのヘルパ（`validateChoices` / `validateRating` / `validateMaxLength`）に分割
- 回答側の `renderQuestion` を質問タイプごとのコンポーネント（`SingleChoiceField` / `MultiChoiceField` / `DropdownField` / `RatingField` / `DateField` / `FreeTextField`）に切り出し

## 動作確認

- `pnpm typecheck` ✅
- `pnpm lint` ✅（残る警告は既存の `app/components/ui/external-link/index.tsx` の `console.info` のみ）
- `pnpm build` ✅

リポジトリにテスト基盤がないため、テストコードは追加していません。

---
_Generated by [Claude Code](https://claude.ai/code/session_011o2AyhrdJxmB1TtTZ5cqgt)_