### PR TITLE
👷 bot が作成した PR でも opencode のレビューが動くようにする

### DIFF
--- a/.github/workflows/opencode-review-bot.yml
+++ b/.github/workflows/opencode-review-bot.yml
@@ -1,0 +1,64 @@
+name: opencode-review (bot PR)
+
+# Dependabot などの bot が作成した PR では pull_request の opencode-review が動かない。
+# 理由は2つ:
+#   1. bot が起こした pull_request イベントでは GITHUB_TOKEN が read-only になり、
+#      Actions secrets (OPENCODE_AUTH_CONTENT) も空になる
+#      https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-on-actions
+#   2. opencode の権限チェックが actor の collaborator 権限を見るが、
+#      bot アカウントは常に permission: none を返すため
+#      "User dependabot[bot] does not have write permissions" で失敗する
+# pull_request_target は base ref が bot 由来でない限りこの制限を受けないため、
+# 信頼できる bot の PR に限りこちらのワークフローでレビューを実行する。
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  review:
+    # pull_request_target は base ブランチの権限で動くため、対象を絞る:
+    # - head が同一リポジトリ内のブランチであること (fork からの PR は対象外)
+    # - PR の作成者が信頼できる bot であること
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["dependabot[bot]", "github-actions[bot]", "claude[bot]", "renovate[bot]"]'), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # pull_request_target のデフォルトどおり base ブランチを checkout する。
+          # レビュー対象の PR ブランチは opencode 自身が fetch する。
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_AUTH_CONTENT: ${{ secrets.OPENCODE_AUTH_CONTENT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # opencode は pull_request_target を未対応イベントとして弾くため、
+          # payload の形が同じ pull_request として扱わせる
+          GITHUB_EVENT_NAME: pull_request
+          # bot アカウントは collaborator permission が常に none になり権限チェックを通らない。
+          # ここでは上の if で「信頼できる bot の PR」に限定済みなので、
+          # 権限チェック用に write 権限を持つユーザーを actor として渡す。
+          # 別のユーザーを使いたい場合はリポジトリ変数 OPENCODE_REVIEW_ACTOR を設定する。
+          GITHUB_ACTOR: ${{ vars.OPENCODE_REVIEW_ACTOR || 'haryoiro' }}
+        with:
+          model: opencode-go/deepseek-v4-pro
+          use_github_token: true
+          prompt: |
+            日本語でレビューしてください。以下のルールを厳守すること:
+            - 実際のコード・ドキュメントから確認できる事実のみを指摘し、推測で「非標準」「存在しない」などと断定しない
+            - API やライブラリのバージョン有無を未確認のまま断言しない
+            - 指摘には必ず該当ファイル・行番号・根拠を明記する
+            - 確信が持てない項目は「要確認」と明示する
+
+            レビュー観点:
+            - コード品質の問題をチェック
+            - 潜在的なバグを探す
+            - 改善点を提案

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   review:
+    # bot が作成した PR は read-only な GITHUB_TOKEN / secrets 不可 で必ず失敗するため、
+    # pull_request_target で動く opencode-review-bot.yml に任せてここではスキップする。
+    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## 背景

Dependabot の PR (#204) で `opencode-review` が失敗していた。
[該当ジョブのログ](https://github.com/neko-dream/web/actions/runs/30333529349/job/90193533509?pr=204) より、原因は 2 つ。

1. **secrets / トークンの制限**
   ログ上 `OPENCODE_AUTH_CONTENT:` が空になっている。bot が起こした `pull_request` イベントでは Actions secrets が参照できず、`GITHUB_TOKEN` も read-only になる（[GitHub Docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-on-actions)）。
2. **opencode の権限チェック**
   `Asserting permissions for user dependabot[bot]... permission: none` → `##[error]User dependabot[bot] does not have write permissions`。
   opencode は actor の collaborator 権限を検証するが、bot アカウントに対して GitHub API は常に `permission: none` を返すため必ず失敗する（upstream issue: [anomalyco/opencode#17224](https://github.com/anomalyco/opencode/issues/17224)）。

`pull_request_target` は base ref が bot 由来でない限りこれらの制限を受けず、書き込み可能な `GITHUB_TOKEN` と Actions secrets が使える。

## 変更内容

**`.github/workflows/opencode-review-bot.yml`（新規）**

- `pull_request_target` で起動するレビュー用ワークフローを追加
- 実行条件を絞る: head が同一リポジトリ内のブランチであること + PR 作成者が信頼できる bot (`dependabot[bot]` / `github-actions[bot]` / `claude[bot]` / `renovate[bot]`) であること
- checkout は base ブランチのまま（レビュー対象の PR ブランチは opencode 自身が fetch する）、`persist-credentials: false`
- `GITHUB_EVENT_NAME: pull_request` を設定。opencode は `pull_request_target` を未対応イベントとして弾くが、payload の形は `pull_request` と同一のため問題なく処理される
- `GITHUB_ACTOR` に write 権限を持つユーザーを渡して権限チェックを通す。対象をすでに信頼できる bot の PR に限定しているため安全側。リポジトリ変数 `OPENCODE_REVIEW_ACTOR` で上書き可能
- permissions は `contents: read` / `pull-requests: write` / `issues: read` に絞った

**`.github/workflows/opencode-review.yml`**

- bot 作成の PR ではジョブをスキップ（新ワークフロー側で実行するため、二重実行と失敗表示を防ぐ）

## 注意点

- `pull_request_target` はワークフローファイルが **base ブランチ側に存在するときだけ** 有効なため、この PR が `develop` にマージされて以降の bot PR から効きます。#204 で確認するには一度 develop にマージしてから `·@·d·ependabot r·ecreate` などで再実行が必要です。
- `pull_request_target` は書き込み可能なトークンで動くため、PR の内容が信頼できない場合はリスクになります。本 PR では fork からの PR を除外し、作成者を bot のホワイトリストに限定しています。ただし PR の diff は LLM のプロンプトに入るため、prompt injection のリスクは残ります（bot のホワイトリストを広げる際は要注意）。

## 動作確認

- YAML の構文チェック（`yaml.safe_load`）のみ実施。Actions 上での実行は develop へのマージ後に確認が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJgC2tE5sNfQVuHMBy8kPf


---
_Generated by [Claude Code](https://claude.ai/code/session_01AJgC2tE5sNfQVuHMBy8kPf)_